### PR TITLE
ENH: groupmeans & crosstabs yileds results one by one

### DIFF
--- a/autolysis/__init__.py
+++ b/autolysis/__init__.py
@@ -9,7 +9,6 @@ import itertools
 import numpy as np
 import blaze as bz
 import pandas as pd
-from orderedattrdict import AttrDict
 from scipy.stats.mstats import ttest_ind
 from scipy.stats import chi2_contingency
 from .metadata import Metadata
@@ -175,9 +174,8 @@ def groupmeans(data, groups, numbers,
     means = {col: bz.into(float, data[col].mean()) for col in numbers}
     # pre-create aggregation expressions (mean, count)
     agg = {number: bz.mean(data[number]) for number in numbers}
-    agg['#'] = bz.count(data)
-    results = []
     for group in groups:
+        agg['#'] = data[group].count()
         ave = bz.by(data[group], **agg).sort('#', ascending=False)
         ave = bz.into(pd.DataFrame, ave)
         ave.index = ave[group]
@@ -211,19 +209,16 @@ def groupmeans(data, groups, numbers,
             )
             if prob > cutoff:
                 continue
-            results.append({
+
+            yield ({
                 'group': group,
                 'number': number,
-                'prob': prob,
+                'prob': float(prob),
                 'gain': sorted_cats.iloc[-1] / means[number] - 1,
-                'biggies': ave.ix[biggies][number],
-                'means': ave[[number, '#']].sort_values(by=number),
+                'biggies': ave.ix[biggies][number].to_dict(),
+                'means': ave[[number, '#']].sort_values(by=number).reset_index().to_dict(
+                    orient='records'),
             })
-
-    results = pd.DataFrame(results)
-    if len(results) > 0:
-        results = results.set_index(['group', 'number'])
-    return results
 
 
 def _crosstab(index, column, values=None, correction=False):
@@ -359,7 +354,6 @@ def crosstabs(data, columns=None, values=None,
     if columns is None:
         columns = types(data)['groups']
 
-    result = AttrDict()
     parameters = ('p', 'chi2', 'dof', 'V')
     for index, column in itertools.combinations(columns, 2):
         agg_col = values if values in data.fields else column
@@ -375,21 +369,25 @@ def crosstabs(data, columns=None, values=None,
         # Remove NULL groups
         data_grouped = data_grouped.dropna()
         if data_grouped.empty:
-            result[(index, column)] = {}
-            continue
-        r = _crosstab(data_grouped[index],
-                      column=data_grouped[column],
-                      values=data_grouped['values'],
-                      correction=correction)
-        if details:
-            result[(index, column)] = {
-                'observed': r['observed'],
-                'expected': r['expected'],
-                'stats': {param: r[param] for param in parameters}
-            }
+            result = {(index, column): {}}
         else:
-            result[(index, column)] = {
-                'stats': {param: r[param] for param in parameters}
-            }
+            r = _crosstab(data_grouped[index],
+                          column=data_grouped[column],
+                          values=data_grouped['values'],
+                          correction=correction)
+            if details:
+                result = {
+                    (index, column): {
+                        'observed': r['observed'],
+                        'expected': r['expected'],
+                        'stats': {param: r[param] for param in parameters}
+                    }
+                }
+            else:
+                result = {
+                    (index, column): {
+                        'stats': {param: r[param] for param in parameters}
+                    }
+                }
 
-    return result
+        yield result

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,4 +1,5 @@
 # Anaconda libraries (to be installed via conda)
 pandas >= 0.17              # Installs NumPy and python-dateutil
 scipy >= 0.16
-blaze >= 0.8
+blaze == 0.9.1
+odo == 0.4.2


### PR DESCRIPTION
This PR contains following changes
1. Groupmeans and crosstabs return yield generator. The results can be pull one after other
2. Test cases for the same
3. Freezing blaze and odo versions in requirements.txt
4. Optimization: bz.count() takes long time compared to data[col_name].count()
