### PR TITLE
OPT: crosstabs output structure modified to json format

### DIFF
--- a/autolysis/__init__.py
+++ b/autolysis/__init__.py
@@ -323,7 +323,7 @@ def _crosstab(index, column, values=None, correction=False):
 def crosstabs(data, columns=None, values=None,
               correction=False,
               pairs_top=10000,
-              details=False):
+              details=True):
     '''
     Identifies the strength of relationship between every pair of categorical
     columns in a DataFrame
@@ -375,17 +375,17 @@ def crosstabs(data, columns=None, values=None,
                           correction=correction)
             if details:
                 result = {
-                    (index, column): {
-                        'observed': r['observed'],
-                        'expected': r['expected'],
+                        'index': index,
+                        'column': column,
+                        'observed': r['observed'].to_json(),
+                        'expected': r['expected'].to_json(),
                         'stats': {param: r[param] for param in parameters}
-                    }
                 }
             else:
                 result = {
-                    (index, column): {
+                        'index': index,
+                        'column': column,
                         'stats': {param: r[param] for param in parameters}
-                    }
                 }
 
         yield result

--- a/tests/test_autolysis.py
+++ b/tests/test_autolysis.py
@@ -169,27 +169,25 @@ class TestGroupMeans(object):
 
 class TestCrossTabs(object):
     "Test autolysis.crosstabs"
-    def check_stats(self, result, expected, msg):
+    def check_stats(self, result, exp, msg):
         if result:
-            stats = {}
             while True:
                 try:
-                    stats.update(next(result))
+                    obs = next(result)
+                    exp_stats = exp[(exp['index'] == obs['index']) &
+                                    (exp['column'] == obs['column'])]['stats'].values[0]
+                    eq_(obs['stats'], exp_stats, 'Test Mismatch with URI: %s ' % msg)
                 except StopIteration:
                     break
-            result = [stats[k]['stats'] for k in sorted(stats)]
-            aaq_(pd.DataFrame(result),
-                 pd.DataFrame(expected),
-                 4,
-                 'Mismatch with URI: %s ' % msg)
         else:
-            eq_([], expected, 'Mismatch with URI: %s ' % msg)
+            eq_([], exp, 'Mismatch with URI: %s ' % msg)
 
     def test_stats(self):
         for dataset in config['datasets']:
             for uri in dataset['uris']:
                 data = Data(uri)
                 groups = dataset['types']['groups']
-                result = al.crosstabs(data, groups)
-                self.check_stats(result, dataset['crosstabs'], uri)
+                result = al.crosstabs(data, groups, details=False)
+                expected = pd.DataFrame(dataset['crosstabs'])
+                self.check_stats(result, expected, uri)
             print('for %s on %s' % (dataset['table'], getengine(dataset['uris'])))

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -24,18 +24,18 @@ datasets:
         databases: [postgres, mysql, sqlite]
         types:
             dates: []
-            groups: [age.group, method, method2, sex]
+            groups: [age.group, method2, method, sex]
             keywords: []
             numbers: [age, Freq]
         groupmeans:
             gain: [0.4942, 0.6000, 2.4484, 2.4484, 0.2718]
         crosstabs: [
-             {V: 0.0, chi2: 0.0, dof: 32, p: 1.0},
-             {V: 0.0, chi2: 0.0, dof: 28, p: 1.0},
-             {V: 0.0, chi2: 0.0, dof: 4, p: 1.0},
-             {V: 1.0, chi2: 2142.0, dof: 56, p: 0.0},
-             {V: 0.0, chi2: 0.0, dof: 8, p: 1.0},
-             {V: 0.0, chi2: 0.0, dof: 7, p: 1.0}]
+             {index: age.group, column: method, stats: {V: 0.0, chi2: 0.0, dof: 32, p: 1.0}},
+             {index: age.group, column: method2, stats: {V: 0.0, chi2: 0.0, dof: 28, p: 1.0}},
+             {index: age.group, column: sex, stats: {V: 0.0, chi2: 0.0, dof: 4, p: 1.0}},
+             {index: method2, column: method, stats: {V: 1.0, chi2: 2142.0, dof: 56, p: 0.0}},
+             {index: method, column: sex, stats: {V: 0.0, chi2: 0.0, dof: 8, p: 1.0}},
+             {index: method2, column: sex, stats: {V: 0.0, chi2: 0.0, dof: 7, p: 1.0}}]
     -
         url: https://data.gov.in/sites/default/files/all_india_PO_list_without_APS_offices_ver2.csv
         big: True


### PR DESCRIPTION
Structure of the crosstabs results are changed to make it json serializable and easy to access the attributes

Earlier structure of crosstabs results. 

```
('city', 'state'): {'stats': {'p': ... , 'V': ..., 'dof': ...}, 'expected':  ..., 'observed': ...}
```

Current structure

```
{'index': 'city', 'column': 'state', {'stats': {'p': ... , 'V': ..., 'dof': ...}, 'expected':  ..., 'observed': ...}}
```
